### PR TITLE
Update URL Encoding Error to send 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Migrated to github.com/golang-jwt/jwt to address a security vulnerability. [#78](https://github.com/xmidt-org/themis/pull/78)
 - Updated spec file and rpkg version macro to be able to choose when the 'v' is included in the version. [#80](https://github.com/xmidt-org/themis/pull/80)
+- Updated transport.go to send a 400 error if there is an issue parsing the URL. [#47](https://github.com/xmidt-org/themis/issues/47)
+
 
 ## [v0.4.7]
 - Migrate to github actions, normalize analysis tools, Dockerfiles and Makefiles. [#67](https://github.com/xmidt-org/themis/pull/67)

--- a/token/errors.go
+++ b/token/errors.go
@@ -1,0 +1,30 @@
+/* Copyright 2022 Comcast Cable Communications Management, LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+ */
+
+package token
+
+type httpError struct {
+	err  error
+	code int
+}
+
+func (e httpError) Error() string {
+	return e.err.Error()
+}
+
+func (e httpError) StatusCode() int {
+	return e.code
+}

--- a/token/transport.go
+++ b/token/transport.go
@@ -293,7 +293,10 @@ func BuildRequest(original *http.Request, rb RequestBuilders) (*Request, error) 
 func DecodeServerRequest(rb RequestBuilders) func(context.Context, *http.Request) (interface{}, error) {
 	return func(ctx context.Context, hr *http.Request) (interface{}, error) {
 		if err := hr.ParseForm(); err != nil {
-			return nil, err
+			return nil, httpError{
+				err:  err,
+				code: http.StatusBadRequest,
+			}
 		}
 
 		tr, err := BuildRequest(hr, rb)


### PR DESCRIPTION
- Updated transport.go to send a 400 error if there is an issue parsing the URL

closes #47 