### PR TITLE
Feature/disable vulnerable ciphers

### DIFF
--- a/xhttp/xhttpserver/tls.go
+++ b/xhttp/xhttpserver/tls.go
@@ -206,6 +206,17 @@ func NewTlsConfig(t *Tls, extra ...PeerVerifier) (*tls.Config, error) {
 		MaxVersion: t.MaxVersion,
 		ServerName: t.ServerName,
 		NextProtos: nextProtos,
+
+		// disable vulnerable ciphers
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		},
+	}
+
+	// if no MinVersion was set, default to TLS 1.2
+	if tc.MinVersion == 0 {
+		tc.MinVersion = tls.VersionTLS12
 	}
 
 	if pvs := NewPeerVerifiers(t.PeerVerify, extra...); len(pvs) > 0 {

--- a/xhttp/xhttpserver/tls_test.go
+++ b/xhttp/xhttpserver/tls_test.go
@@ -493,7 +493,7 @@ func testNewTlsConfigSimple(t *testing.T, certificateFile, keyFile string) {
 	require.NoError(err)
 	require.NotNil(tc)
 
-	assert.Zero(tc.MinVersion)
+	assert.Equal(tls.VersionTLS12, tc.MinVersion)
 	assert.Zero(tc.MaxVersion)
 	assert.Empty(tc.ServerName)
 	assert.Equal([]string{"http/1.1"}, tc.NextProtos)
@@ -543,7 +543,7 @@ func testNewTlsConfigWithClientCACertificateFile(t *testing.T, certificateFile, 
 	require.NoError(err)
 	require.NotNil(tc)
 
-	assert.Zero(tc.MinVersion)
+	assert.Equal(tls.VersionTLS12, tc.MinVersion)
 	assert.Zero(tc.MaxVersion)
 	assert.Empty(tc.ServerName)
 	assert.Equal([]string{"http/1.1"}, tc.NextProtos)

--- a/xhttp/xhttpserver/tls_test.go
+++ b/xhttp/xhttpserver/tls_test.go
@@ -493,7 +493,7 @@ func testNewTlsConfigSimple(t *testing.T, certificateFile, keyFile string) {
 	require.NoError(err)
 	require.NotNil(tc)
 
-	assert.Equal(tls.VersionTLS12, tc.MinVersion)
+	assert.Equal(uint16(tls.VersionTLS12), tc.MinVersion)
 	assert.Zero(tc.MaxVersion)
 	assert.Empty(tc.ServerName)
 	assert.Equal([]string{"http/1.1"}, tc.NextProtos)
@@ -543,7 +543,7 @@ func testNewTlsConfigWithClientCACertificateFile(t *testing.T, certificateFile, 
 	require.NoError(err)
 	require.NotNil(tc)
 
-	assert.Equal(tls.VersionTLS12, tc.MinVersion)
+	assert.Equal(uint16(tls.VersionTLS12), tc.MinVersion)
 	assert.Zero(tc.MaxVersion)
 	assert.Empty(tc.ServerName)
 	assert.Equal([]string{"http/1.1"}, tc.NextProtos)

--- a/xhttp/xhttpserver/unmarshal_test.go
+++ b/xhttp/xhttpserver/unmarshal_test.go
@@ -120,10 +120,9 @@ func testUnmarshalProvideOptional(t *testing.T) {
 func testUnmarshalProvideRequired(t *testing.T) {
 	var (
 		assert = assert.New(t)
-
-		app = fx.New(
+		app    = fx.New(
+			sallust.WithLogger(),
 			fx.Provide(
-				fx.Logger(sallust.Printer{}),
 				sallust.Default,
 				config.ProvideViper(),
 				Unmarshal{Key: "server"}.Provide,
@@ -144,9 +143,8 @@ func testUnmarshalProvideUnmarshalError(t *testing.T) {
 		assert = assert.New(t)
 
 		app = fx.New(
+			sallust.WithLogger(),
 			fx.Provide(
-				fx.Logger(sallust.Printer{}),
-				sallust.Default,
 				config.ProvideViper(
 					config.Json(`
 						{
@@ -175,9 +173,8 @@ func testUnmarshalProvideChainFactoryError(t *testing.T) {
 		expectedErr = errors.New("expected chain factory error")
 
 		app = fx.New(
+			sallust.WithLogger(),
 			fx.Provide(
-				fx.Logger(sallust.Printer{}),
-				sallust.Default,
 				config.ProvideViper(
 					config.Json(`
 						{
@@ -226,8 +223,8 @@ func testUnmarshalAnnotatedFull(t *testing.T) {
 
 		router *mux.Router
 		app    = fxtest.New(t,
+			fx.Supply(sallust.Default()),
 			fx.Provide(
-				sallust.Default,
 				config.ProvideViper(
 					config.Json(`
 						{


### PR DESCRIPTION
This disables TLS 1.0 and 1.1 in addition to setting the `CipherSuites` struct field to allow only strong ciphers.

There were also a lot of test breaks left over from the sallust changes.  I've fixed those and reduced the test logging output.