### PR TITLE
Feature/cert info in handler

### DIFF
--- a/token/claimBuilder_test.go
+++ b/token/claimBuilder_test.go
@@ -545,7 +545,7 @@ func (suite *NewClaimBuildersTestSuite) TestMinimum() {
 	)
 
 	suite.Equal(
-		map[string]interface{}{"request": 123},
+		map[string]interface{}{"request": 123, "trust": 0},
 		actual,
 	)
 }
@@ -691,6 +691,7 @@ func (suite *NewClaimBuildersTestSuite) TestStatic() {
 			"static1": suite.rawMessage(-72.5),
 			"static2": suite.rawMessage([]string{"a", "b"}),
 			"request": 123,
+			"trust":   0,
 		},
 		actual,
 	)
@@ -737,6 +738,7 @@ func (suite *NewClaimBuildersTestSuite) TestNoRemote() {
 			"iat":     suite.expectedNow.UTC().Unix(),
 			"nbf":     suite.expectedNow.Add(15 * time.Second).UTC().Unix(),
 			"exp":     suite.expectedNow.Add(24 * time.Hour).UTC().Unix(),
+			"trust":   0,
 		},
 		actual,
 	)
@@ -821,6 +823,7 @@ func (suite *NewClaimBuildersTestSuite) TestFull() {
 			"iat":     suite.expectedNow.UTC().Unix(),
 			"nbf":     suite.expectedNow.Add(15 * time.Second).UTC().Unix(),
 			"exp":     suite.expectedNow.Add(24 * time.Hour).UTC().Unix(),
+			"trust":   0,
 		},
 		actual,
 	)

--- a/token/factory.go
+++ b/token/factory.go
@@ -4,6 +4,7 @@ package token
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"sync/atomic"
 
@@ -26,6 +27,10 @@ type Request struct {
 	// Metadata holds non-claim information about the request, usually garnered from the original HTTP request.  This
 	// metadata is available to lower levels of infrastructure used by the Factory.
 	Metadata map[string]interface{}
+
+	// ConnectionState represents the state of any underlying TLS connection.
+	// For non-tls connections, this field is unset.
+	ConnectionState tls.ConnectionState
 }
 
 // NewRequest returns an empty, fully initialized token Request

--- a/token/transport.go
+++ b/token/transport.go
@@ -19,12 +19,6 @@ import (
 	"go.uber.org/multierr"
 )
 
-const (
-	// ClaimTrust is the name of the trust value within JWT claims issued
-	// by themis.
-	ClaimTrust = "trust"
-)
-
 var (
 	ErrVariableNotAllowed = errors.New("Either header/parameter or variable can specified, but not all three")
 )

--- a/token/unmarshal_test.go
+++ b/token/unmarshal_test.go
@@ -22,7 +22,6 @@ func testUnmarshalError(t *testing.T) {
 
 	app := fx.New(
 		fx.Provide(
-			fx.Logger(sallust.Printer{}),
 			config.ProvideViper(
 				config.Json(`
 					{
@@ -49,7 +48,6 @@ func testUnmarshalClaimBuilderError(t *testing.T) {
 
 		app = fx.New(
 			fx.Provide(
-				fx.Logger(sallust.Printer{}),
 				config.ProvideViper(
 					config.Json(`
 						{
@@ -84,7 +82,6 @@ func testUnmarshalFactoryError(t *testing.T) {
 
 		app = fx.New(
 			fx.Provide(
-				fx.Logger(sallust.Printer{}),
 				config.ProvideViper(
 					config.Json(`
 						{

--- a/xhttp/xhttpserver/server.go
+++ b/xhttp/xhttpserver/server.go
@@ -4,6 +4,7 @@ package xhttpserver
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 	"net/http"
 	"time"
@@ -98,6 +99,18 @@ func New(o Options, l *zap.Logger, h http.Handler) Interface {
 			o.Address,
 			l,
 		),
+
+		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+			type connectionStater interface {
+				ConnectionState() tls.ConnectionState
+			}
+
+			if cs, ok := c.(connectionStater); ok {
+				ctx = SetConnectionState(ctx, cs.ConnectionState())
+			}
+
+			return ctx
+		},
 	}
 
 	if o.LogConnectionState {

--- a/xhttp/xhttpserver/server_test.go
+++ b/xhttp/xhttpserver/server_test.go
@@ -212,6 +212,7 @@ func testNewSimple(t *testing.T) {
 	assert.Greater(output.Len(), 0)
 
 	assert.Nil(s.(*http.Server).ConnState)
+	assert.NotNil(s.(*http.Server).ConnContext)
 }
 
 func testNewFull(t *testing.T) {

--- a/xhttp/xhttpserver/tls.go
+++ b/xhttp/xhttpserver/tls.go
@@ -3,6 +3,7 @@
 package xhttpserver
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -248,4 +249,21 @@ func NewTlsConfig(t *Tls, extra ...PeerVerifier) (*tls.Config, error) {
 
 	tc.BuildNameToCertificate() // nolint: staticcheck
 	return tc, nil
+}
+
+type connectionStateKey struct{}
+
+// ConnectionState returns the tls.ConnectionState from the given context.
+func ConnectionState(ctx context.Context) (cs tls.ConnectionState, present bool) {
+	cs, present = ctx.Value(connectionStateKey{}).(tls.ConnectionState)
+	return
+}
+
+// SetConnectionState associates a tls.ConnectionState with the given context.
+func SetConnectionState(ctx context.Context, cs tls.ConnectionState) context.Context {
+	return context.WithValue(
+		ctx,
+		connectionStateKey{},
+		cs,
+	)
 }


### PR DESCRIPTION
This PR does (2) things:

(1) Wires in the tls.ConnectionState with the higher levels of application code, particularly the ClaimsBuilder.
(2) Overrides any configured trust, setting it to zero (0), if no peer certificates are sent by the client.