### PR TITLE
feat: allow claims to be used for response headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ report.json
 # for VSCode
 .vscode/
 .dev/
+__debug_bin*
 
 # for releases
 .ignore/

--- a/token/endpoint.go
+++ b/token/endpoint.go
@@ -4,25 +4,76 @@ package token
 
 import (
 	"context"
+	"net/http"
+	"time"
 
 	"github.com/go-kit/kit/endpoint"
 )
 
+const (
+	JWTExpHeader = "Expires"
+)
+
 // NewIssueEndpoint returns a go-kit endpoint for a token factory's NewToken method
-func NewIssueEndpoint(f Factory) endpoint.Endpoint {
+func NewIssueEndpoint(f Factory, headerClaims map[string]string) endpoint.Endpoint {
 	return func(ctx context.Context, v interface{}) (interface{}, error) {
-		return f.NewToken(ctx, v.(*Request))
+		req := v.(*Request)
+		resp := Response{
+			Claims:       make(map[string]interface{}, len(req.Claims)),
+			HeaderClaims: headerClaims,
+		}
+		token, err := f.NewToken(ctx, req, resp.Claims)
+		if err != nil {
+			return Response{}, err
+		}
+
+		resp.Body = []byte(token)
+
+		return resp, err
 	}
 }
 
 // NewClaimsEndpoint returns a go-kit endpoint that returns just the claims
-func NewClaimsEndpoint(cb ClaimBuilder) endpoint.Endpoint {
+func NewClaimsEndpoint(cb ClaimBuilder, headerClaims map[string]string) endpoint.Endpoint {
 	return func(ctx context.Context, v interface{}) (interface{}, error) {
-		merged := make(map[string]interface{})
-		if err := cb.AddClaims(ctx, v.(*Request), merged); err != nil {
+		resp := Response{
+			Claims:       make(map[string]interface{}),
+			HeaderClaims: headerClaims,
+		}
+		if err := cb.AddClaims(ctx, v.(*Request), resp.Claims); err != nil {
 			return nil, err
 		}
 
-		return merged, nil
+		return resp.Claims, nil
 	}
+}
+
+type Response struct {
+	// Claims is the set of token claims.
+	Claims map[string]interface{}
+	// HeaderClaims is a map of claims-to-headers, where each claim will be attempted to be added as response header.
+	HeaderClaims map[string]string
+	// Body is the response body used by the EncodeIssueResponse.
+	Body []byte
+}
+
+// Headers creates and returns a set of http headers based on HeaderClaims.
+// Any failures to add claims are silent and does not affect the response.
+func (resp Response) Headers() http.Header {
+	headers := http.Header{}
+	for claimKey, headerName := range resp.HeaderClaims {
+		c, ok := resp.Claims[claimKey]
+		if !ok {
+			continue
+		}
+
+		switch v := c.(type) {
+		case time.Time:
+			headers.Add(headerName, v.Format(http.TimeFormat))
+		case string:
+			headers.Add(headerName, v)
+		}
+	}
+
+	return headers
 }

--- a/token/mocks_test.go
+++ b/token/mocks_test.go
@@ -12,13 +12,13 @@ type mockFactory struct {
 	mock.Mock
 }
 
-func (m *mockFactory) NewToken(ctx context.Context, r *Request) (string, error) {
-	arguments := m.Called(ctx, r)
+func (m *mockFactory) NewToken(ctx context.Context, r *Request, claims map[string]interface{}) (string, error) {
+	arguments := m.Called(ctx, r, claims)
 	return arguments.String(0), arguments.Error(1)
 }
 
-func (m *mockFactory) ExpectNewToken(ctx context.Context, r *Request) *mock.Call {
-	return m.On("NewToken", ctx, r)
+func (m *mockFactory) ExpectNewToken(ctx context.Context, r *Request, claims map[string]interface{}) *mock.Call {
+	return m.On("NewToken", ctx, r, claims)
 }
 
 type mockClaimBuilder struct {

--- a/token/options.go
+++ b/token/options.go
@@ -108,6 +108,11 @@ type Options struct {
 	// or statically from configuration.  For special processing around the partner id, set the PartnerID field.
 	Claims []Value
 
+	// HeaderClaims is an optional map of claims-to-headers, where each claim will be attempted to be added as response header.
+	//
+	// Any failures to add claims are silent and does not affect the response.
+	HeaderClaims map[string]string
+
 	// Metadata describes non-claim data, which can be statically configured or supplied via a request
 	Metadata []Value
 

--- a/token/transport.go
+++ b/token/transport.go
@@ -328,9 +328,16 @@ func DecodeServerRequest(rb RequestBuilders) func(context.Context, *http.Request
 	}
 }
 
-func EncodeIssueResponse(_ context.Context, response http.ResponseWriter, value interface{}) error {
-	response.Header().Set("Content-Type", "application/jose")
-	_, err := response.Write([]byte(value.(string)))
+func EncodeIssueResponse(_ context.Context, w http.ResponseWriter, value interface{}) error {
+	resp := value.(Response)
+	for k, values := range resp.Headers() {
+		for _, v := range values {
+			w.Header().Set(k, v)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/jose")
+	_, err := w.Write(resp.Body)
 	return err
 }
 

--- a/token/transport_test.go
+++ b/token/transport_test.go
@@ -612,7 +612,7 @@ func TestEncodeIssueResponse(t *testing.T) {
 		assert  = assert.New(t)
 		require = require.New(t)
 
-		expectedValue = "expected"
+		expectedValue = Response{Body: []byte("expected")}
 		response      = httptest.NewRecorder()
 	)
 
@@ -621,7 +621,7 @@ func TestEncodeIssueResponse(t *testing.T) {
 	)
 
 	assert.Equal("application/jose", response.Header().Get("Content-Type"))
-	assert.Equal(expectedValue, response.Body.String())
+	assert.Equal(expectedValue.Body, response.Body.Bytes())
 }
 
 func testDecodeRemoteClaimsResponseSuccess(t *testing.T) {

--- a/token/unmarshal.go
+++ b/token/unmarshal.go
@@ -58,11 +58,11 @@ func Unmarshal(configKey string, b ...RequestBuilder) func(TokenIn) (TokenOut, e
 			ClaimBuilder: cb,
 			Factory:      f,
 			IssueHandler: NewIssueHandler(
-				NewIssueEndpoint(f),
+				NewIssueEndpoint(f, o.HeaderClaims),
 				rb,
 			),
 			ClaimsHandler: NewClaimsHandler(
-				NewClaimsEndpoint(cb),
+				NewClaimsEndpoint(cb, o.HeaderClaims),
 				rb,
 			),
 		}, nil


### PR DESCRIPTION
- allow token claims to be used for response headers
- add optional config to determine which claims will be added as what header
- update tests