### PR TITLE
fix entrypoint.sh

### DIFF
--- a/.release/docker/entrypoint.sh
+++ b/.release/docker/entrypoint.sh
@@ -1,6 +1,6 @@
+#!/usr/bin/env sh
 # SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
-#!/usr/bin/env sh
 set -e
 
 # check arguments for an option that would cause /themis to stop


### PR DESCRIPTION
the sh directive has to be first.  copyright stuff has to go after the directive. 